### PR TITLE
Update linked-lists.c

### DIFF
--- a/src/linked-lists/linked-lists.c
+++ b/src/linked-lists/linked-lists.c
@@ -61,7 +61,6 @@ void insert(Node **list, int value) {
     insertAtRear(list, value);
   } else {
     // add somewhere in the middle
-    Node *new_node = createNode(value);
     Node *p = (*list)->next;
 
     while (p) {
@@ -72,6 +71,8 @@ void insert(Node **list, int value) {
       }
       p = p->next;
     }
+
+    Node *new_node = createNode(value);
 
     new_node->next = p;
     new_node->prev = p->prev;


### PR DESCRIPTION
Move new_node below while loop.  In this case, when we hit the case value == p->value, we hit a return. This is a bug. Every time this case is met, we allocate a new node but we lose the reference to it. Memory leak!